### PR TITLE
Add Results header to Average BPM post

### DIFF
--- a/_notebooks/2020-04-28-avg-bpm.ipynb
+++ b/_notebooks/2020-04-28-avg-bpm.ipynb
@@ -336,6 +336,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Finally, for fun, we can draw a line at 138 BPM to compare."
    ]
   },

--- a/_posts/2020-04-28-avg-bpm.md
+++ b/_posts/2020-04-28-avg-bpm.md
@@ -332,6 +332,12 @@ Episode average:  148.7766
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
+<h2 id="Results">Results<a class="anchor-link" href="#Results"> </a></h2>
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
 <p>Finally, for fun, we can draw a line at 138 BPM to compare.</p>
 
 </div>


### PR DESCRIPTION
Adding a "Results" header to the Average BPM post.